### PR TITLE
Suppress warnings from intellij code analyzer

### DIFF
--- a/src/main/java/org/fluentd/kafka/GroupConsumer.java
+++ b/src/main/java/org/fluentd/kafka/GroupConsumer.java
@@ -112,7 +112,7 @@ public class GroupConsumer {
 
         try {
             // Need better long running approach.
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 Thread.sleep(10000);
             }
         } catch (InterruptedException e) {

--- a/src/main/java/org/fluentd/kafka/GroupConsumer.java
+++ b/src/main/java/org/fluentd/kafka/GroupConsumer.java
@@ -49,15 +49,17 @@ public class GroupConsumer {
         LOG.info("Shutting down consumers");
 
         if (consumer != null) consumer.shutdown();
-        if (executor != null) executor.shutdown();
-        try {
-            if (!executor.awaitTermination(5000, TimeUnit.MILLISECONDS)) {
-                LOG.error("Timed out waiting for consumer threads to shut down, exiting uncleanly");
+        if (executor != null) {
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(5000, TimeUnit.MILLISECONDS)) {
+                    LOG.error("Timed out waiting for consumer threads to shut down, exiting uncleanly");
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted during shutdown, exiting uncleanly");
                 executor.shutdownNow();
             }
-        } catch (InterruptedException e) {
-            LOG.error("Interrupted during shutdown, exiting uncleanly");
-            executor.shutdownNow();
         }
 
         try {


### PR DESCRIPTION
`GroupConsumer#executor` may cause Null Pointer Exception. We should always check `executor` whether null or not.

Use !Thread.currentThread().isInterrupted() instead of true. Because while(true) does not complete without throw InterruptedException.
