### PR TITLE
Specify UTF-8 charset explicitly

### DIFF
--- a/src/main/java/org/fluentd/kafka/FluentdHandler.java
+++ b/src/main/java/org/fluentd/kafka/FluentdHandler.java
@@ -1,6 +1,7 @@
 package org.fluentd.kafka;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +66,7 @@ public class FluentdHandler implements Runnable {
                     throw e;
                 } catch (Exception e) {
                     Map<String, Object> data = new HashMap<String, Object>();
-                    data.put("message", new String(entry.message()));
+                    data.put("message", new String(entry.message(), StandardCharsets.UTF_8));
                     logger.emit("failed", data); // should be configurable
                 }
             } catch (IOException e) {

--- a/src/main/java/org/fluentd/kafka/parser/JsonParser.java
+++ b/src/main/java/org/fluentd/kafka/parser/JsonParser.java
@@ -1,5 +1,6 @@
 package org.fluentd.kafka.parser;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.HashMap;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class JsonParser extends MessageParser {
     @Override
     public Map<String, Object> parse(MessageAndMetadata<byte[], byte[]> entry) throws Exception {
         try {
-            return mapper.readValue(new String(entry.message()), typeRef);
+            return mapper.readValue(new String(entry.message(), StandardCharsets.UTF_8), typeRef);
         } catch (IOException e) {
             throw new RuntimeException(e); // Avoid IOException conflict with fluency logger
         }

--- a/src/main/java/org/fluentd/kafka/parser/RegexpParser.java
+++ b/src/main/java/org/fluentd/kafka/parser/RegexpParser.java
@@ -1,5 +1,6 @@
 package org.fluentd.kafka.parser;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -22,7 +23,7 @@ public class RegexpParser extends MessageParser {
     public RegexpParser(PropertyConfig config) {
         super(config);
 
-        byte[] pattern = config.get("fluentd.record.pattern").getBytes();
+        byte[] pattern = config.get("fluentd.record.pattern").getBytes(StandardCharsets.UTF_8);
         regex = new Regex(pattern, 0, pattern.length, Option.DEFAULT, UTF8Encoding.INSTANCE);
         entries = setupNamedGroupEntries();
     }
@@ -41,11 +42,11 @@ public class RegexpParser extends MessageParser {
                 if (region.beg[index] == -1)
                     continue;
 
-                String value = new String(rawMessage, region.beg[index], region.end[index] - region.beg[index]);
+                String value = new String(rawMessage, region.beg[index], region.end[index] - region.beg[index], StandardCharsets.UTF_8);
                 data.put(e.name, value);
             }
         } else {
-            throw new RuntimeException("message has wrong format: message = " + new String(rawMessage));
+            throw new RuntimeException("message has wrong format: message = " + new String(rawMessage, StandardCharsets.UTF_8));
         }
 
         return data;
@@ -59,7 +60,7 @@ public class RegexpParser extends MessageParser {
             NameEntry e = entryIt.next();
             int index = e.getBackRefs()[0];
 
-            entries[i] = new NamedGroupEntry(new String(e.name, e.nameP, e.nameEnd - e.nameP), index);
+            entries[i] = new NamedGroupEntry(new String(e.name, e.nameP, e.nameEnd - e.nameP, StandardCharsets.UTF_8), index);
             i++;
         }
 


### PR DESCRIPTION
Because this project already specifies UTF-8 here: https://github.com/treasure-data/kafka-fluentd-consumer/compare/master...cosmo0920:specify-utf-8-charset-explicitly?expand=1#diff-d59d607e85e7df6d9fdf1d7bc318bc21R27

And `new String(bytes[], ...)` without charset arguments assumes that `ISO-8859-1` encoding by default not `UTF-8`.
