### PR TITLE
Upgrade fluency to 0.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.komamitsu', name: 'fluency', version: '0.0.10'
+    compile group: 'org.komamitsu', name: 'fluency', version: '0.0.11'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.12'
     compile group: "org.apache.kafka", name: "kafka_2.10", version: "0.8.2.0"


### PR DESCRIPTION
I fixed this bug (https://github.com/komamitsu/fluency/pull/23) of fluency and released the fix in 0.0.11. This bug happens only when `Fluency#emit` passes a huge data at once compared to configurated buffer size. But I recommend you to use 0.0.11 just in case.
