### PR TITLE
Log ConsumerTimeoutException in debugging mode

### DIFF
--- a/src/main/java/org/fluentd/kafka/FluentdHandler.java
+++ b/src/main/java/org/fluentd/kafka/FluentdHandler.java
@@ -151,6 +151,7 @@ public class FluentdHandler implements Runnable {
             it.hasNext();
             return true;
         } catch (ConsumerTimeoutException e) {
+            LOG.debug("Consumption was timed out", e);
             return false;
         }
     }


### PR DESCRIPTION
## Abstract

Add logging process in the `catch` block of `ConsumerTimeoutException`.

## Reason

kafka-fluentd-consumer suddenly had come to consume records slowly but there was not any messages on the kafka-fluentd-consumer's log.

I managed to find that `ConsumerTimeoutException` was thrown frequently by appending debugging code on the kafka-fluentd-consumer source code, building it and deploying it.

I thought that it was useful to notify developers/operators of the occurrence of `ConsumerTimeoutException` in debugging mode, so I added this logging process to the source code.