### PR TITLE
Update kafka client library to avoid zkclient bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile group: 'org.komamitsu', name: 'fluency', version: '1.7.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.12'
-    compile group: "org.apache.kafka", name: "kafka_2.10", version: "0.8.2.0"
+    compile group: "org.apache.kafka", name: "kafka_2.10", version: "0.9.0.1"
     compile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.8.1"
     compile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.8.1"
     compile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.8.1"


### PR DESCRIPTION
NullPointerException occured in zkclient when I used kafka-fluentd-consumer 0.3.1 in our environment(HDP 2.4.0 and Kafka 0.9.0.2.4).

```
java.lang.NullPointerException
        at org.I0Itec.zkclient.ZkConnection.exists(ZkConnection.java:95)
        at org.I0Itec.zkclient.ZkClient$3.call(ZkClient.java:439)
        at org.I0Itec.zkclient.ZkClient$3.call(ZkClient.java:436)
        at org.I0Itec.zkclient.ZkClient.retryUntilConnected(ZkClient.java:675)
        at org.I0Itec.zkclient.ZkClient.exists(ZkClient.java:436)
        at org.I0Itec.zkclient.ZkClient.exists(ZkClient.java:445)
        at org.I0Itec.zkclient.ZkClient$7.run(ZkClient.java:566)
        at org.I0Itec.zkclient.ZkEventThread.run(ZkEventThread.java:71)
```

I think that this is zkclient bug https://github.com/sgroschupf/zkclient/issues/25

kafka-fluentd-consumer 0.3.1 depends on kafka 0.8.2.0 and kafka 0.8.2.0 depends on zkclient 0.3.

https://github.com/treasure-data/kafka-fluentd-consumer/blob/v0.3.1/build.gradle#L21
http://central.maven.org/maven2/org/apache/kafka/kafka_2.10/0.8.2.0/kafka_2.10-0.8.2.0.pom 

kafka 0.9.0.1 depends on zkclient 0.7 which fix this NPE bug.
http://central.maven.org/maven2/org/apache/kafka/kafka_2.10/0.9.0.1/kafka_2.10-0.9.0.1.pom

It's been over 1 week since I patched this pull request and deployed in our environment.
Currently, it's no problem.