### PR TITLE
skipping corrupted message and logging unhandled exception for dead consumer thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
-version = '0.3.2'
+version = '0.3.4'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.6'

--- a/src/main/java/org/fluentd/kafka/FluentdHandler.java
+++ b/src/main/java/org/fluentd/kafka/FluentdHandler.java
@@ -108,6 +108,8 @@ public class FluentdHandler implements Runnable {
                             ex = e2;
                         } catch (IllegalArgumentException e3) { // message crc error will throw IllegalArgumentException
                             ex = e3;
+                        } catch (IndexOutOfBoundsException e4) {
+                            ex = e4;
                         }
                     }
 


### PR DESCRIPTION
Corrupted message will cause `entry.message()` to throw `IllegalArgumentException`. And we also need to log unhandled exception for consumer thread.